### PR TITLE
dev: allow to run services with different environments

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -170,3 +170,7 @@ packages/**/lib
 
 tools/**/package-lock.json
 tools/**/lib
+
+/config/*
+!/config/default.*
+!/config/test.*

--- a/.gitignore
+++ b/.gitignore
@@ -171,6 +171,7 @@ packages/**/lib
 tools/**/package-lock.json
 tools/**/lib
 
+# Only store default and test configs
 /config/*
 !/config/default.*
 !/config/test.*

--- a/config/default.js
+++ b/config/default.js
@@ -1,5 +1,4 @@
 exports.database = {
-  type: 'postgres',
   host: 'localhost',
   port: 5432,
   database: 'webok',

--- a/config/default.js
+++ b/config/default.js
@@ -1,0 +1,8 @@
+exports.database = {
+  type: 'postgres',
+  host: 'localhost',
+  port: 5432,
+  database: 'webok',
+  username: 'webok_user',
+  password: 'webok_secret',
+}

--- a/config/test.js
+++ b/config/test.js
@@ -1,0 +1,3 @@
+exports.database = {
+  port: 15432,
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -3,16 +3,12 @@ services:
   postgres:
     image: postgres:alpine
     volumes:
-      - postgres_dev_data:/var/lib/postgresql/data
-    networks:
-      - dev_network
+      - postgres_data:/var/lib/postgresql/data
     environment:
-      POSTGRES_DB: webok_dev
-      POSTGRES_USER: webok_dev_user
-      POSTGRES_PASSWORD: webok_dev_secret
+      POSTGRES_DB: webok
+      POSTGRES_USER: webok_user
+      POSTGRES_PASSWORD: webok_secret
     ports:
-      - 5432:5432
+      - ${DATABASE_PORT:-5432}:5432
 volumes:
-  postgres_dev_data:
-networks:
-  dev_network:
+  postgres_data:

--- a/package-lock.json
+++ b/package-lock.json
@@ -2163,6 +2163,11 @@
         "@types/node": "*"
       }
     },
+    "@types/config": {
+      "version": "0.0.34",
+      "resolved": "https://registry.npmjs.org/@types/config/-/config-0.0.34.tgz",
+      "integrity": "sha512-jWi9DXx77hnzN4kHCNEvP/kab+nchRLTg9yjXYxjTcMBkuc5iBb3QuwJ4sPrb+nzy1GQjrfyfMqZOdR4i7opRQ=="
+    },
     "@types/cross-spawn": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.0.tgz",
@@ -2278,9 +2283,9 @@
       },
       "dependencies": {
         "camelcase": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
+          "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ=="
         }
       }
     },
@@ -2295,9 +2300,9 @@
       },
       "dependencies": {
         "camelcase": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
+          "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ=="
         }
       }
     },
@@ -2317,6 +2322,11 @@
         "vue-template-es2015-compiler": "^1.9.0"
       },
       "dependencies": {
+        "cssesc": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+          "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
+        },
         "lru-cache": {
           "version": "4.1.5",
           "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -2324,6 +2334,16 @@
           "requires": {
             "pseudomap": "^1.0.2",
             "yallist": "^2.1.2"
+          }
+        },
+        "postcss-selector-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+          "requires": {
+            "cssesc": "^2.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
           }
         },
         "prettier": {
@@ -2639,9 +2659,9 @@
       }
     },
     "ansi-colors": {
-      "version": "3.2.3",
-      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
-      "integrity": "sha512-LEHHyuhlPY3TmuUYMh2oz89lTShfvgbmzaBcxve9t/9Wuy7Dwf4yoAKcND7KFT1HAQfqZ12qtc+DUrBMeKF9nw=="
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
+      "integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA=="
     },
     "ansi-escapes": {
       "version": "3.2.0",
@@ -2901,12 +2921,12 @@
       "integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg=="
     },
     "autoprefixer": {
-      "version": "9.4.9",
-      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.9.tgz",
-      "integrity": "sha512-OyUl7KvbGBoFQbGQu51hMywz1aaVeud/6uX8r1R1DNcqFvqGUUy6+BDHnAZE8s5t5JyEObaSw+O1DpAdjAmLuw==",
+      "version": "9.4.10",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.4.10.tgz",
+      "integrity": "sha512-XR8XZ09tUrrSzgSlys4+hy5r2/z4Jp7Ag3pHm31U4g/CTccYPOVe19AkaJ4ey/vRd1sfj+5TtuD6I0PXtutjvQ==",
       "requires": {
         "browserslist": "^4.4.2",
-        "caniuse-lite": "^1.0.30000939",
+        "caniuse-lite": "^1.0.30000940",
         "normalize-range": "^0.1.2",
         "num2fraction": "^1.2.2",
         "postcss": "^7.0.14",
@@ -3151,9 +3171,9 @@
           "integrity": "sha512-iB5Dda8t/UqpPI/IjsejXu5jOGDrzn41wJyljwPH65VCIbk6+1BzFIMJGFwTNrYXT1CrD+B4l19U7awiQ8rk7w=="
         },
         "camelcase": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-          "integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+          "version": "5.2.0",
+          "resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.2.0.tgz",
+          "integrity": "sha512-IXFsBS2pC+X0j0N/GE7Dm7j3bsEBp+oTpb7F50dwEVX7rf3IgwO9XatnegTsDtniKCUtEJH4fSU6Asw7uoVLfQ=="
         },
         "is-fullwidth-code-point": {
           "version": "2.0.0",
@@ -3526,9 +3546,9 @@
       }
     },
     "caniuse-lite": {
-      "version": "1.0.30000939",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000939.tgz",
-      "integrity": "sha512-oXB23ImDJOgQpGjRv1tCtzAvJr4/OvrHi5SO2vUgB0g0xpdZZoA/BxfImiWfdwoYdUTtQrPsXsvYU/dmCSM8gg=="
+      "version": "1.0.30000941",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30000941.tgz",
+      "integrity": "sha512-4vzGb2MfZcO20VMPj1j6nRAixhmtlhkypM4fL4zhgzEucQIYiRzSqPcWIu1OF8i0FETD93FMIPWfUJCAcFvrqA=="
     },
     "caseless": {
       "version": "0.12.0",
@@ -4062,6 +4082,15 @@
         "typedarray": "^0.0.6"
       }
     },
+    "config": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/config/-/config-3.0.1.tgz",
+      "integrity": "sha512-TBNrrk2b6AybUohqXw2AydglFBL9b/+1GG93Di6Fm6x1SyVJ5PYgo+mqY2X0KpU9m0PJDSbFaC5H95utSphtLw==",
+      "dev": true,
+      "requires": {
+        "json5": "^1.0.1"
+      }
+    },
     "config-chain": {
       "version": "1.1.12",
       "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.12.tgz",
@@ -4413,6 +4442,23 @@
       "requires": {
         "postcss": "^7.0.6",
         "postcss-selector-parser": "^5.0.0-rc.4"
+      },
+      "dependencies": {
+        "cssesc": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+          "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
+        },
+        "postcss-selector-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+          "requires": {
+            "cssesc": "^2.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
       }
     },
     "css-loader": {
@@ -4456,46 +4502,6 @@
       "resolved": "https://registry.npmjs.org/css-select-base-adapter/-/css-select-base-adapter-0.1.1.tgz",
       "integrity": "sha512-jQVeeRG70QI08vSTwf1jHxp74JoZsr2XSgETae8/xC8ovSnL2WF87GTLO86Sbwdt2lK4Umg4HnnwMO4YF3Ce7w=="
     },
-    "css-selector-tokenizer": {
-      "version": "0.7.1",
-      "resolved": "https://registry.npmjs.org/css-selector-tokenizer/-/css-selector-tokenizer-0.7.1.tgz",
-      "integrity": "sha512-xYL0AMZJ4gFzJQsHUKa5jiWWi2vH77WVNg7JYRyewwj6oPh4yb/y6Y9ZCw9dsj/9UauMhtuxR+ogQd//EdEVNA==",
-      "requires": {
-        "cssesc": "^0.1.0",
-        "fastparse": "^1.1.1",
-        "regexpu-core": "^1.0.0"
-      },
-      "dependencies": {
-        "jsesc": {
-          "version": "0.5.0",
-          "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-0.5.0.tgz",
-          "integrity": "sha1-597mbjXW/Bb3EP6R1c9p9w8IkR0="
-        },
-        "regexpu-core": {
-          "version": "1.0.0",
-          "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-1.0.0.tgz",
-          "integrity": "sha1-hqdj9Y7k18L2sQLkdkBQ3n7ZDGs=",
-          "requires": {
-            "regenerate": "^1.2.1",
-            "regjsgen": "^0.2.0",
-            "regjsparser": "^0.1.4"
-          }
-        },
-        "regjsgen": {
-          "version": "0.2.0",
-          "resolved": "https://registry.npmjs.org/regjsgen/-/regjsgen-0.2.0.tgz",
-          "integrity": "sha1-bAFq3qxVT3WCP+N6wFuS1aTtsfc="
-        },
-        "regjsparser": {
-          "version": "0.1.5",
-          "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
-          "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
-          "requires": {
-            "jsesc": "~0.5.0"
-          }
-        }
-      }
-    },
     "css-tree": {
       "version": "1.0.0-alpha.28",
       "resolved": "https://registry.npmjs.org/css-tree/-/css-tree-1.0.0-alpha.28.tgz",
@@ -4526,9 +4532,9 @@
       "integrity": "sha512-VHPES/+c9s+I0ryNj+PXvp84nz+ms843z/efpaEINwP/QfGsINL3gpLp5qjapzDNzNzbXxur8uxKxSXImrg4ag=="
     },
     "cssesc": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-0.1.0.tgz",
-      "integrity": "sha1-yBSQPkViM3GgR3tAEJqq++6t27Q="
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-3.0.0.tgz",
+      "integrity": "sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg=="
     },
     "cssnano": {
       "version": "4.1.10",
@@ -5223,9 +5229,9 @@
       "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "eslint": {
-      "version": "5.15.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.0.tgz",
-      "integrity": "sha512-xwG7SS5JLeqkiR3iOmVgtF8Y6xPdtr6AAsN6ph7Q6R/fv+3UlKYoika8SmNzmb35qdRF+RfTY35kMEdtbi+9wg==",
+      "version": "5.15.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-5.15.1.tgz",
+      "integrity": "sha512-NTcm6vQ+PTgN3UBsALw5BMhgO6i5EpIjQF/Xb5tIh3sk9QhrFafujUOczGz4J24JBlzWclSB9Vmx8d+9Z6bFCg==",
       "requires": {
         "@babel/code-frame": "^7.0.0",
         "ajv": "^6.9.1",
@@ -5468,9 +5474,9 @@
       "integrity": "sha512-qzm/XxIbxm/FHyH341ZrbnMUpe+5Bocte9xkmFMzPMjRaZMcXww+MpBptFvtU+79L362nqiLhekCxCxDPaUMBQ=="
     },
     "esm": {
-      "version": "3.2.9",
-      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.9.tgz",
-      "integrity": "sha512-mATFs9dpCjnEyNv27z29UNDmJmBBX8zMdcFip7aIOrBRTpLs8SA+6Ek1QtsWfvecAJVeZy+X5D3Z6xZVtUvYdg=="
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.11.tgz",
+      "integrity": "sha512-OhgzK4tmov6Ih2gQ28k8e5kV07sGgEKG+ys3PqbDd2FBXpsZkGpFotFbrm0+KmuD2ktaV4hdPYQTDMpq9FjeTA=="
     },
     "espree": {
       "version": "5.0.1",
@@ -5807,22 +5813,15 @@
       }
     },
     "extract-css-chunks-webpack-plugin": {
-      "version": "3.3.2",
-      "resolved": "https://registry.npmjs.org/extract-css-chunks-webpack-plugin/-/extract-css-chunks-webpack-plugin-3.3.2.tgz",
-      "integrity": "sha512-7XNEW3AiFiWqOCxJyjNDMqk+PMwqSQhrAr/NobhlI1fxb0a4AqlgCn3+dxlcqTlD+MhRz0jI4u3bXmw3jyoBVQ==",
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/extract-css-chunks-webpack-plugin/-/extract-css-chunks-webpack-plugin-3.3.3.tgz",
+      "integrity": "sha512-4DYo3jna9ov81rdKtE1U2cirb3ERoWhHldzRxZWx3Q5i5Dm6U+mmfon7PmaKDuh6+xySVOqtlXrZyJY2V4tc+g==",
       "requires": {
         "loader-utils": "^1.1.0",
         "lodash": "^4.17.11",
-        "normalize-url": "^4.1.0",
+        "normalize-url": "^3.3.0",
         "schema-utils": "^1.0.0",
         "webpack-sources": "^1.1.0"
-      },
-      "dependencies": {
-        "normalize-url": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-4.2.0.tgz",
-          "integrity": "sha512-n69+KXI+kZApR+sPwSkoAXpGlNkaiYyoHHqKOFPjJWvwZpew/EjKvuPE4+tStNgb42z5yLtdakgZCQI+LalSPg=="
-        }
       }
     },
     "extsprintf": {
@@ -5875,11 +5874,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-1.2.0.tgz",
       "integrity": "sha1-69QmZv0Y/k8rpPDSlQZfP4XK3pY="
-    },
-    "fastparse": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
-      "integrity": "sha512-483XLLxTVIwWK3QTrMGRqUfUpoOs/0hbQrl2oz4J0pAcm3A3bu84wxTFqGqkJzewCLdME38xJLJAxBABfQT8sQ=="
     },
     "figgy-pudding": {
       "version": "3.5.1",
@@ -5991,9 +5985,9 @@
           }
         },
         "p-limit": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-          "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -7136,9 +7130,9 @@
           }
         },
         "p-limit": {
-          "version": "2.1.0",
-          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.1.0.tgz",
-          "integrity": "sha512-NhURkNcrVB+8hNfLuysU8enY5xn2KXphsHBaC2YmRNTZRc7RWusw6apSpdEj3jo4CMb6W9nrF6tTnsJsJeyu6g==",
+          "version": "2.2.0",
+          "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-2.2.0.tgz",
+          "integrity": "sha512-pZbTJpoUsCzV48Mc9Nh51VbwO0X9cuPFE8gYwx9BTCt9SF8/b7Zljd2fVgOxhIF/HDTKgpVzs+GPhyKfjLLFRQ==",
           "requires": {
             "p-try": "^2.0.0"
           }
@@ -8393,9 +8387,9 @@
       }
     },
     "luxon": {
-      "version": "1.11.3",
-      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.11.3.tgz",
-      "integrity": "sha512-/0jMa+JfTRBx1ixsSBs5ZPAQ32H+TPeP9BvgRf0Gi4VxCqhUpRNWagwupy6wA8MckazneKWBLCcwwAH8hkQamg=="
+      "version": "1.11.4",
+      "resolved": "https://registry.npmjs.org/luxon/-/luxon-1.11.4.tgz",
+      "integrity": "sha512-zTQ1DCShOGHIdNpa56yjDpUCowKDsBqeFVuEG2XBcrAM2udxN0g3N5RTZzbw94OkDiBgECsuDgLNnQTo73yghw=="
     },
     "macos-release": {
       "version": "2.0.0",
@@ -8985,9 +8979,9 @@
       "integrity": "sha512-UdS4swXs85fCGWWf6t6DMGgpN/vnlKeSGEQ7hJcrs7PBFoxoKLmibc3QRb7fwiYsjdL7PX8iI/TMSlZ90dgHhQ=="
     },
     "node-releases": {
-      "version": "1.1.8",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.8.tgz",
-      "integrity": "sha512-gQm+K9mGCiT/NXHy+V/ZZS1N/LOaGGqRAAJJs3X9Ah1g+CIbRcBgNyoNYQ+SEtcyAtB9KqDruu+fF7nWjsqRaA==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.9.tgz",
+      "integrity": "sha512-oic3GT4OtbWWKfRolz5Syw0Xus0KRFxeorLNj0s93ofX6PWyuzKjsiGxsCtWktBwwmTF6DdRRf2KreGqeOk5KA==",
       "requires": {
         "semver": "^5.3.0"
       }
@@ -9868,6 +9862,23 @@
       "requires": {
         "postcss": "^7.0.2",
         "postcss-selector-parser": "^5.0.0"
+      },
+      "dependencies": {
+        "cssesc": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+          "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
+        },
+        "postcss-selector-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+          "requires": {
+            "cssesc": "^2.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
       }
     },
     "postcss-calc": {
@@ -9879,6 +9890,23 @@
         "postcss": "^7.0.5",
         "postcss-selector-parser": "^5.0.0-rc.4",
         "postcss-value-parser": "^3.3.1"
+      },
+      "dependencies": {
+        "cssesc": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+          "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
+        },
+        "postcss-selector-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+          "requires": {
+            "cssesc": "^2.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
       }
     },
     "postcss-color-functional-notation": {
@@ -9973,6 +10001,23 @@
       "requires": {
         "postcss": "^7.0.2",
         "postcss-selector-parser": "^5.0.0-rc.3"
+      },
+      "dependencies": {
+        "cssesc": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+          "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
+        },
+        "postcss-selector-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+          "requires": {
+            "cssesc": "^2.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
       }
     },
     "postcss-dir-pseudo-class": {
@@ -9982,6 +10027,23 @@
       "requires": {
         "postcss": "^7.0.2",
         "postcss-selector-parser": "^5.0.0-rc.3"
+      },
+      "dependencies": {
+        "cssesc": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+          "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
+        },
+        "postcss-selector-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+          "requires": {
+            "cssesc": "^2.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
       }
     },
     "postcss-discard-comments": {
@@ -10281,22 +10343,22 @@
       }
     },
     "postcss-modules-local-by-default": {
-      "version": "2.0.5",
-      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-2.0.5.tgz",
-      "integrity": "sha512-iFgxlCAVLno5wIJq+4hyuOmc4VjZEZxzpdeuZcBytLNWEK5Bx2oRF9PPcAz5TALbaFvrZm8sJYtJ3hV+tMSEIg==",
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/postcss-modules-local-by-default/-/postcss-modules-local-by-default-2.0.6.tgz",
+      "integrity": "sha512-oLUV5YNkeIBa0yQl7EYnxMgy4N6noxmiwZStaEJUSe2xPMcdNc8WmBQuQCx18H5psYbVxz8zoHk0RAAYZXP9gA==",
       "requires": {
-        "css-selector-tokenizer": "^0.7.0",
         "postcss": "^7.0.6",
+        "postcss-selector-parser": "^6.0.0",
         "postcss-value-parser": "^3.3.1"
       }
     },
     "postcss-modules-scope": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.0.1.tgz",
-      "integrity": "sha512-7+6k9c3/AuZ5c596LJx9n923A/j3nF3ormewYBF1RrIQvjvjXe1xE8V8A1KFyFwXbvnshT6FBZFX0k/F1igneg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/postcss-modules-scope/-/postcss-modules-scope-2.1.0.tgz",
+      "integrity": "sha512-91Rjps0JnmtUB0cujlc8KIKCsJXWjzuxGeT/+Q2i2HXKZ7nBUeF9YQTZZTNvHVoNYj1AthsjnGLtqDUE0Op79A==",
       "requires": {
-        "css-selector-tokenizer": "^0.7.0",
-        "postcss": "^7.0.6"
+        "postcss": "^7.0.6",
+        "postcss-selector-parser": "^6.0.0"
       }
     },
     "postcss-modules-values": {
@@ -10492,6 +10554,23 @@
       "requires": {
         "postcss": "^7.0.2",
         "postcss-selector-parser": "^5.0.0-rc.3"
+      },
+      "dependencies": {
+        "cssesc": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
+          "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
+        },
+        "postcss-selector-parser": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
+          "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+          "requires": {
+            "cssesc": "^2.0.0",
+            "indexes-of": "^1.0.1",
+            "uniq": "^1.0.1"
+          }
+        }
       }
     },
     "postcss-reduce-initial": {
@@ -10543,20 +10622,13 @@
       }
     },
     "postcss-selector-parser": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-5.0.0.tgz",
-      "integrity": "sha512-w+zLE5Jhg6Liz8+rQOWEAwtwkyqpfnmsinXjXg6cY7YIONZZtgvE0v2O0uhQBs0peNomOJwWRKt6JBfTdTd3OQ==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.1.tgz",
+      "integrity": "sha512-bg46FvHx2lSHput5J4xCiCHrRxjza73jceSW8JcOVNzCEnlhuZF7pLa7K0KpNt8whL7C8V5wdb0bSrCRg0w13g==",
       "requires": {
-        "cssesc": "^2.0.0",
+        "cssesc": "^3.0.0",
         "indexes-of": "^1.0.1",
         "uniq": "^1.0.1"
-      },
-      "dependencies": {
-        "cssesc": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/cssesc/-/cssesc-2.0.0.tgz",
-          "integrity": "sha512-MsCAG1z9lPdoO/IUMLSBWBSVxVtJ1395VGIQ+Fc2gNdkQ1hNDnQdw3YhA71WJCBW1vdwA0cAnk/DnW6bqoEUYg=="
-        }
       }
     },
     "postcss-svgo": {
@@ -11026,9 +11098,9 @@
       "integrity": "sha512-1G6jJVDWrt0rK99kBjvEtziZNCICAuvIPkSiUFIQxVP06RCVpq3dmDo2oi6ABpYaDYaTRr67BEhL8r1wgEZZKg=="
     },
     "regenerate-unicode-properties": {
-      "version": "7.0.0",
-      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-7.0.0.tgz",
-      "integrity": "sha512-s5NGghCE4itSlUS+0WUj88G6cfMVMmH8boTPNvABf8od+2dhT9WDlWu8n01raQAJZMOK8Ch6jSexaRO7swd6aw==",
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/regenerate-unicode-properties/-/regenerate-unicode-properties-8.0.1.tgz",
+      "integrity": "sha512-HTjMafphaH5d5QDHuwW8Me6Hbc/GhXg8luNqTkPVwZ/oCZhnoifjWhGYsu2BzepMELTlbnoVcXvV0f+2uDDvoQ==",
       "requires": {
         "regenerate": "^1.4.0"
       }
@@ -11066,16 +11138,16 @@
       "integrity": "sha512-lv0M6+TkDVniA3aD1Eg0DVpfU/booSu7Eev3TDO/mZKHBfVjgCGTV4t4buppESEYDtkArYFOxTJWv6S5C+iaNw=="
     },
     "regexpu-core": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.4.0.tgz",
-      "integrity": "sha512-eDDWElbwwI3K0Lo6CqbQbA6FwgtCz4kYTarrri1okfkRLZAqstU+B3voZBCjg8Fl6iq0gXrJG6MvRgLthfvgOA==",
+      "version": "4.5.3",
+      "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-4.5.3.tgz",
+      "integrity": "sha512-LON8666bTAlViVEPXMv65ZqiaR3rMNLz36PIaQ7D+er5snu93k0peR7FSvO0QteYbZ3GOkvfHKbGr/B1xDu9FA==",
       "requires": {
         "regenerate": "^1.4.0",
-        "regenerate-unicode-properties": "^7.0.0",
+        "regenerate-unicode-properties": "^8.0.1",
         "regjsgen": "^0.5.0",
         "regjsparser": "^0.6.0",
         "unicode-match-property-ecmascript": "^1.0.4",
-        "unicode-match-property-value-ecmascript": "^1.0.2"
+        "unicode-match-property-value-ecmascript": "^1.1.0"
       }
     },
     "registry-auth-token": {
@@ -12676,14 +12748,14 @@
       }
     },
     "unicode-match-property-value-ecmascript": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.0.2.tgz",
-      "integrity": "sha512-Rx7yODZC1L/T8XKo/2kNzVAQaRE88AaMvI1EF/Xnj3GW2wzN6fop9DDWuFAKUVFH7vozkz26DzP0qyWLKLIVPQ=="
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/unicode-match-property-value-ecmascript/-/unicode-match-property-value-ecmascript-1.1.0.tgz",
+      "integrity": "sha512-hDTHvaBk3RmFzvSl0UVrUmC3PuW9wKVnpoUDYH0JDkSIovzw+J5viQmeYHxVSBptubnr7PbH2e0fnpDRQnQl5g=="
     },
     "unicode-property-aliases-ecmascript": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.4.tgz",
-      "integrity": "sha512-2WSLa6OdYd2ng8oqiGIWnJqyFArvhn+5vgx5GTxMbUYjCYKUcuKS62YLFF0R/BDGlB1yzXjQOLtPAfHsgirEpg=="
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/unicode-property-aliases-ecmascript/-/unicode-property-aliases-ecmascript-1.0.5.tgz",
+      "integrity": "sha512-L5RAqCfXqAwR3RriF8pM0lU0w4Ryf/GgzONwi6KnL1taJQa7x1TCxdJnILX59WIGOwR57IVxn7Nej0fz1Ny6fw=="
     },
     "union-value": {
       "version": "1.0.0",
@@ -13476,9 +13548,9 @@
       }
     },
     "ws": {
-      "version": "6.1.4",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.1.4.tgz",
-      "integrity": "sha512-eqZfL+NE/YQc1/ZynhojeV8q+H050oR8AZ2uIev7RU10svA9ZnJUddHcOUZTJLinZ9yEfdA2kSATS2qZK5fhJA==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.0.tgz",
+      "integrity": "sha512-deZYUNlt2O4buFCa3t5bKLf8A7FPP/TVjwOeVNpw818Ma5nk4MLXls2eoEGS39o8119QIYxTrTDoPQ5B/gTD6w==",
       "requires": {
         "async-limiter": "~1.0.0"
       }

--- a/package.json
+++ b/package.json
@@ -13,11 +13,11 @@
     "watch": "node ./scripts/dev watch build",
     "prewatch": "npm run build",
     "check:deps": "node ./scripts/dev checkdeps",
-    "start:services": "docker-compose up -d",
     "publish:try": "node ./scripts/dev run publish:prepare && lerna version --no-push",
     "publish:now": "node ./scripts/dev run publish:prepare && lerna publish"
   },
   "devDependencies": {
+    "config": "^3.0.1",
     "lerna": "^3.13.1"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,6 +13,8 @@
     "watch": "node ./scripts/dev watch build",
     "prewatch": "npm run build",
     "check:deps": "node ./scripts/dev checkdeps",
+    "services:start": "node ./scripts/services start",
+    "services:stop": "node ./scripts/services stop",
     "publish:try": "node ./scripts/dev run publish:prepare && lerna version --no-push",
     "publish:now": "node ./scripts/dev run publish:prepare && lerna publish"
   },

--- a/packages/api/package.json
+++ b/packages/api/package.json
@@ -10,7 +10,7 @@
     "postformat": "npm run tslint",
     "tslint": "webok-dev tslint",
     "publish:prepare": "npm run clean && npm run build",
-    "dev": "node lib/main.js"
+    "dev": "NODE_CONFIG_DIR=../../config node lib/main.js"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/api/src/page/page.controller.ts
+++ b/packages/api/src/page/page.controller.ts
@@ -1,5 +1,11 @@
 import { Controller, Get, Post, Patch, Delete, Param, Body, NotFoundException } from '@nestjs/common'
-import { ApiUseTags, ApiOkResponse, ApiCreatedResponse, ApiNotFoundResponse, ApiBadRequestResponse } from '@nestjs/swagger'
+import {
+  ApiUseTags,
+  ApiOkResponse,
+  ApiCreatedResponse,
+  ApiNotFoundResponse,
+  ApiBadRequestResponse,
+} from '@nestjs/swagger'
 import { PageService, Page, CreatePageData, UpdatePageData } from '@webok/core/lib/page'
 import { ParamsWithId } from '../common/controller'
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -9,9 +9,9 @@
     "postformat": "npm run tslint",
     "tslint": "webok-dev tslint",
     "publish:prepare": "npm run clean && npm run build",
-    "migration:generate": "ts-node ./node_modules/.bin/typeorm migration:generate -f src/typeorm.config -n",
-    "migration:run": "ts-node ./node_modules/.bin/typeorm migration:run -f src/typeorm.config",
-    "migration:revert": "ts-node ./node_modules/.bin/typeorm migration:revert -f src/typeorm.config"
+    "migration:generate": "NODE_CONFIG_DIR=../../config ts-node ./node_modules/.bin/typeorm migration:generate -f src/typeorm.config -n",
+    "migration:run": "NODE_CONFIG_DIR=../../config ts-node ./node_modules/.bin/typeorm migration:run -f src/typeorm.config",
+    "migration:revert": "NODE_CONFIG_DIR=../../config ts-node ./node_modules/.bin/typeorm migration:revert -f src/typeorm.config"
   },
   "publishConfig": {
     "access": "public"
@@ -20,12 +20,14 @@
     "@nestjs/swagger": "^2.5.1",
     "@nestjs/typeorm": "^5.3.0",
     "class-validator": "^0.9.1",
+    "config": "^3.0.1",
     "luxon": "^1.11.3",
     "pg": "^7.8.1",
     "typeorm": "^0.2.14",
     "typescript-optional": "^2.0.1"
   },
   "devDependencies": {
+    "@types/config": "^0.0.34",
     "@types/luxon": "^1.11.1",
     "@webok/dev": "^0.0.0",
     "ts-node": "^8.0.2"

--- a/packages/core/src/load-config.ts
+++ b/packages/core/src/load-config.ts
@@ -1,0 +1,7 @@
+// TODO find a better way to load config in production
+
+process.env.NODE_CONFIG_DIR = '../../../config'
+
+import config from 'config'
+
+export { config }

--- a/packages/core/src/load-config.ts
+++ b/packages/core/src/load-config.ts
@@ -1,7 +1,0 @@
-// TODO find a better way to load config in production
-
-process.env.NODE_CONFIG_DIR = '../../../config'
-
-import config from 'config'
-
-export { config }

--- a/packages/core/src/page/page.service.ts
+++ b/packages/core/src/page/page.service.ts
@@ -22,7 +22,7 @@ export class CreatePageData {
 export class UpdatePageData {
   @ApiModelPropertyOptional()
   @IsOptional()
-  @IsString() 
+  @IsString()
   readonly name?: string
 
   @ApiModelPropertyOptional()

--- a/packages/core/src/typeorm.config.ts
+++ b/packages/core/src/typeorm.config.ts
@@ -5,9 +5,9 @@ const TypeOrmConfig: TypeOrmModuleOptions = {
   type: 'postgres',
   host: 'localhost',
   port: 5432,
-  database: 'webok_dev',
-  username: 'webok_dev_user',
-  password: 'webok_dev_secret',
+  database: 'webok',
+  username: 'webok_user',
+  password: 'webok_secret',
   entities: [path.join(__dirname, '**/*.entity{.ts,.js}')],
   // Migrations
   migrationsTableName: 'typeorm_migrations',

--- a/packages/core/src/typeorm.config.ts
+++ b/packages/core/src/typeorm.config.ts
@@ -1,13 +1,19 @@
 import path from 'path'
 import { TypeOrmModuleOptions } from '@nestjs/typeorm'
+// TODO find a better way to load config in production, currently use root config by NODE_CONFIG_DIR
+import config from 'config'
+
+interface DatabaseConfig {
+  host: string
+  port: number
+  database: string
+  username: string
+  password: string
+}
 
 const TypeOrmConfig: TypeOrmModuleOptions = {
   type: 'postgres',
-  host: 'localhost',
-  port: 5432,
-  database: 'webok',
-  username: 'webok_user',
-  password: 'webok_secret',
+  ...config.get<DatabaseConfig>('database'),
   entities: [path.join(__dirname, '**/*.entity{.ts,.js}')],
   // Migrations
   migrationsTableName: 'typeorm_migrations',

--- a/scripts/services.js
+++ b/scripts/services.js
@@ -1,0 +1,8 @@
+const config = require('config')
+const { createServices } = require('../tools/dev/lib/services')
+
+const services = createServices(config)
+
+if (require.main === module) {
+  services(process.argv.slice(2))
+}

--- a/tools/dev/package.json
+++ b/tools/dev/package.json
@@ -39,6 +39,7 @@
   },
   "devDependencies": {
     "@types/chokidar": "^1.7.5",
+    "@types/config": "^0.0.34",
     "@types/cross-spawn": "^6.0.0",
     "@types/node": "^11.10.4",
     "@types/package-json": "^5.0.0",

--- a/tools/dev/src/binaries/create-binary.ts
+++ b/tools/dev/src/binaries/create-binary.ts
@@ -1,13 +1,22 @@
 import whichFactory from 'npm-which'
 import spawn from 'cross-spawn'
+import { SpawnOptions } from 'child_process'
 
 const which = whichFactory(process.cwd())
 
-export const createBinary = (command: string) => (...argv: string[]): Promise<number> => {
-  console.log(`> ${command} ${argv.map((arg) => `'${arg}'`).join(' ')}`)
-  return new Promise<number>((resolve, reject) => {
-    spawn(which.sync(command), argv, { stdio: ['pipe', process.stdout, process.stderr] })
-      .on('close', resolve)
-      .on('error', reject)
-  })
+export const createBinary = (command: string) => {
+  const binary = createBinaryWithOptions(command)
+  return (...argv: string[]): Promise<number> => binary(argv)
+}
+
+export const createBinaryWithOptions = (command: string) => {
+  const fullCommand = which.sync(command)
+  return (argv: string[], options?: SpawnOptions): Promise<number> => {
+    console.log(`> ${command} ${argv.map((arg) => `'${arg}'`).join(' ')}`)
+    return new Promise<number>((resolve, reject) => {
+      spawn(fullCommand, argv, { stdio: ['pipe', process.stdout, process.stderr], ...options })
+        .on('close', resolve)
+        .on('error', reject)
+    })
+  }
 }

--- a/tools/dev/src/binaries/create-binary.ts
+++ b/tools/dev/src/binaries/create-binary.ts
@@ -6,6 +6,7 @@ const which = whichFactory(process.cwd())
 
 export const createBinary = (command: string) => {
   const binary = createBinaryWithOptions(command)
+  // Run binary with no extra options
   return (...argv: string[]): Promise<number> => binary(argv)
 }
 

--- a/tools/dev/src/cli.ts
+++ b/tools/dev/src/cli.ts
@@ -1,23 +1,10 @@
 #!/usr/bin/env node
 
 import commands from './commands'
+import { runCLI } from './run-cli'
 
 export const cli = (argv: string[]) => {
-  const [commandName, ...commandArgv] = argv
-  const command = commands[commandName]
-  if (!command) {
-    throw new Error(`Command not found: ${commandName}`)
-  }
-  command(commandArgv)
-    .then((exitCode) => {
-      if (exitCode) {
-        process.exit(exitCode)
-      }
-    })
-    .catch((err) => {
-      console.error(err)
-      process.exit(1)
-    })
+  runCLI(argv, commands)
 }
 
 if (require.main === module) {

--- a/tools/dev/src/run-cli.ts
+++ b/tools/dev/src/run-cli.ts
@@ -1,0 +1,17 @@
+export const runCLI = (argv: string[], commands: Record<string, (argv: string[]) => Promise<number>>) => {
+  const [commandName, ...commandArgv] = argv
+  const command = commands[commandName]
+  if (!command) {
+    throw new Error(`Command not found: ${commandName}`)
+  }
+  command(commandArgv)
+    .then((exitCode) => {
+      if (exitCode) {
+        process.exit(exitCode)
+      }
+    })
+    .catch((err) => {
+      console.error(err)
+      process.exit(1)
+    })
+}

--- a/tools/dev/src/services.ts
+++ b/tools/dev/src/services.ts
@@ -1,0 +1,30 @@
+import { IConfig } from 'config'
+import { runCLI } from './run-cli'
+import { createBinaryWithOptions } from './binaries/create-binary'
+
+const appId = 'webok'
+const env = process.env.NODE_ENV || 'development'
+const dockerProjectId = `${appId}${env}`
+const dockerCompose = createBinaryWithOptions('docker-compose')
+
+const createCommands = (config: IConfig) => {
+  const start = (argv: string[]): Promise<number> => {
+    return dockerCompose(['-p', dockerProjectId, 'up', '-d', ...argv], {
+      env: {
+        DATABASE_PORT: `${config.get<{ port: number }>('database').port}`,
+      },
+    })
+  }
+  const stop = (argv: string[]): Promise<number> => {
+    return dockerCompose(['-p', dockerProjectId, 'down', ...argv])
+  }
+  return { start, stop }
+}
+
+// Create a CLI to start and stop development services
+export const createServices = (config: IConfig) => {
+  const commands = createCommands(config)
+  return (argv: string[]) => {
+    runCLI(argv, commands)
+  }
+}

--- a/tools/dev/src/types/npm-which.d.ts
+++ b/tools/dev/src/types/npm-which.d.ts
@@ -1,6 +1,6 @@
 declare module 'npm-which' {
   interface Which {
-    sync: (cmd: string) => string
+    sync(cmd: string): string
   }
   export default function whichFactory(cwd: string): Which
 }


### PR DESCRIPTION
Part of #16. Allow to use Docker services such as postgres in different ports configured per environment (development, test, etc.).

1. To start services:
- Development: `npm run services:start` (postgres at port 5432)
- Test: `NODE_ENV=test npm run services:start` (postgres at port 15432)

2. To stop services:
- Development: `npm run services:stop` (will keep postgres data volume)
- Test: `NODE_ENV=test npm run services:stop -- -v` (will remove postgres data volume)

3. To run migration:
```
cd packages/core
```
- Development: `npm run migration:run`
- Test: `NODE_ENV=test npm run migration:run`

4. To run API server:
```
cd packages/api
```
- Development: `npm run dev`
- Test: `NODE_ENV=test npm run dev`

**TODO: find a better way to load config in production, currently use root config by NODE_CONFIG_DIR**
