### PR TITLE
dev: add pagination and sorting into page find api

### DIFF
--- a/packages/api/src/page/page.controller.ts
+++ b/packages/api/src/page/page.controller.ts
@@ -13,6 +13,7 @@ import {
   Param,
   Patch,
   Post,
+  Query,
   UseGuards,
 } from '@nestjs/common'
 import { AuthGuard } from '@nestjs/passport'
@@ -29,7 +30,7 @@ import {
   ApiUseTags,
 } from '@nestjs/swagger'
 import { AuthRequestInterface } from '@webok/core/lib/auth'
-import { CreatePageDto, PageDto, UpdatePageDto } from '@webok/core/lib/page'
+import { CreatePageDto, FindPagesDto, PageDto, UpdatePageDto } from '@webok/core/lib/page'
 import { PageService } from '@webok/services/lib/page'
 import { IsNumberString } from 'class-validator'
 import { UserId } from '../auth'
@@ -61,8 +62,8 @@ export class PageController {
   @ApiBearerAuth()
   @ApiOkResponse({ type: [PageDto] })
   @ApiUnauthorizedResponse({})
-  async find (@UserId() userId: number): Promise<PageDto[]> {
-    const pageDtos: PageDto[] = await this.pageService.find({ ownerId: userId })
+  async find (@Query() findPageDto: FindPagesDto, @UserId() userId: number): Promise<PageDto[]> {
+    const pageDtos: PageDto[] = await this.pageService.find(findPageDto, userId)
     return pageDtos
   }
 

--- a/packages/core/src/page/find-pages.dto.ts
+++ b/packages/core/src/page/find-pages.dto.ts
@@ -1,8 +1,20 @@
-import { ApiModelProperty } from '@nestjs/swagger'
-import { IsNumber } from 'class-validator'
+import { ApiModelPropertyOptional } from '@nestjs/swagger'
+import { IsIn, IsNumberString } from 'class-validator'
 
 export class FindPagesDto {
-  @ApiModelProperty()
-  @IsNumber()
-  readonly ownerId?: number
+  @ApiModelPropertyOptional()
+  @IsNumberString()
+  skip?: number
+
+  @ApiModelPropertyOptional()
+  @IsNumberString()
+  take?: number
+
+  @ApiModelPropertyOptional()
+  @IsIn(['name', 'url', 'createdAt'])
+  sort?: string
+
+  @ApiModelPropertyOptional()
+  @IsIn(['ASC', 'DESC'])
+  dir?: 'ASC' | 'DESC'
 }


### PR DESCRIPTION
- To paginate: GET /pages with **_skip_** and **_take_** query. (e.g. pages?skip=0&take=10)
- To sort: GET /pages with **_sort_** (name/url/createdAt) and **_dir_** (ASC/DESC) query. (e.g. pages?sort=name&dir=ASC)

Close #63.